### PR TITLE
Fix parallel execution in REST and Hive engines

### DIFF
--- a/src/main/java/com/yahoo/validatar/execution/EngineManager.java
+++ b/src/main/java/com/yahoo/validatar/execution/EngineManager.java
@@ -136,8 +136,7 @@ public class EngineManager extends Pluggable<Engine> implements Helpable {
     protected boolean startEngines(List<Query> queries) {
         List<Query> all = queries == null ? Collections.emptyList() : queries;
         // Queries -> engine name Set -> start engine -> verify all started
-        return all.stream().map(q -> q.engine).collect(Collectors.toSet())
-               .stream().allMatch(this::startEngine);
+        return all.stream().map(q -> q.engine).distinct().allMatch(this::startEngine);
     }
 
     private boolean startEngine(String engine) {

--- a/src/main/java/com/yahoo/validatar/execution/rest/JSON.java
+++ b/src/main/java/com/yahoo/validatar/execution/rest/JSON.java
@@ -74,7 +74,6 @@ public class JSON implements Engine {
     private int defaultRetries = DEFAULT_RETRIES;
     private String defaultFunction = DEFAULT_FUNCTION_NAME;
 
-    //private ScriptEngine evaluator;
     private ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
 
     private static final String JSON_TO_MAP_FORMAT = "Java.asJSONCompatible(%s)";
@@ -101,7 +100,6 @@ public class JSON implements Engine {
 
     @Override
     public boolean setup(String[] arguments) {
-        //evaluator = new ScriptEngineManager().getEngineByName(JAVASCRIPT_ENGINE);
         OptionSet options = parser.parse(arguments);
         defaultTimeout = (Integer) options.valueOf(TIMEOUT_KEY);
         defaultRetries = (Integer) options.valueOf(RETRY_KEY);

--- a/src/main/java/com/yahoo/validatar/execution/rest/JSON.java
+++ b/src/main/java/com/yahoo/validatar/execution/rest/JSON.java
@@ -74,7 +74,8 @@ public class JSON implements Engine {
     private int defaultRetries = DEFAULT_RETRIES;
     private String defaultFunction = DEFAULT_FUNCTION_NAME;
 
-    private ScriptEngine evaluator;
+    //private ScriptEngine evaluator;
+    private ScriptEngineManager scriptEngineManager = new ScriptEngineManager();
 
     private static final String JSON_TO_MAP_FORMAT = "Java.asJSONCompatible(%s)";
 
@@ -100,7 +101,7 @@ public class JSON implements Engine {
 
     @Override
     public boolean setup(String[] arguments) {
-        evaluator = new ScriptEngineManager().getEngineByName(JAVASCRIPT_ENGINE);
+        //evaluator = new ScriptEngineManager().getEngineByName(JAVASCRIPT_ENGINE);
         OptionSet options = parser.parse(arguments);
         defaultTimeout = (Integer) options.valueOf(TIMEOUT_KEY);
         defaultRetries = (Integer) options.valueOf(RETRY_KEY);
@@ -142,8 +143,9 @@ public class JSON implements Engine {
         Objects.requireNonNull(metadata);
         String data = makeRequest(createClient(metadata), createRequest(metadata), query);
         String function = metadata.getOrDefault(METADATA_FUNCTION_NAME_KEY, String.valueOf(defaultFunction));
-        String columnarData = convertToColumnarJSON(data, function, query);
-        Map<String, List<TypedObject>> typedData = convertToMap(columnarData, query);
+        ScriptEngine evaluator = scriptEngineManager.getEngineByName(JAVASCRIPT_ENGINE);
+        String columnarData = convertToColumnarJSON(data, evaluator, function, query);
+        Map<String, List<TypedObject>> typedData = convertToMap(columnarData, evaluator, query);
         query.createResults().addColumns(typedData);
     }
 
@@ -151,10 +153,11 @@ public class JSON implements Engine {
      * Converts the String columnar JSON data into a Map of column names to List of column values. Internal use only.
      *
      * @param columnarData The String columnar JSON data.
+     * @param evaluator The Javascript engine used to convert the String columnar JSON data.
      * @param query The Query object being run.
      * @return The Map version of the JSON data, null if exception (query is failed).
      */
-    Map<String, List<TypedObject>> convertToMap(String columnarData, Query query) {
+    Map<String, List<TypedObject>> convertToMap(String columnarData, ScriptEngine evaluator, Query query) {
         try {
             log.info("Converting processed JSON into a map...");
             // Type erasure will make this not enough if the JSON parses into a map but with the wrong keys, values.
@@ -179,11 +182,12 @@ public class JSON implements Engine {
      * Uses the user provided query to process and return a JSON columnar format of the data.
      *
      * @param data The data from the REST call.
+     * @param evaluator The Javascript engine used to invoke the function on the data.
      * @param function The function name to invoke.
      * @param query The Query object being run.
      * @return The String JSON response of the call, null if exception (query is failed).
      */
-    String convertToColumnarJSON(String data, String function, Query query) {
+    String convertToColumnarJSON(String data, ScriptEngine evaluator, String function, Query query) {
         try {
             log.info("Evaluating query using Javascript function: {}\n{}", function, query.value);
             evaluator.eval(query.value);

--- a/src/test/java/com/yahoo/validatar/AppTest.java
+++ b/src/test/java/com/yahoo/validatar/AppTest.java
@@ -15,7 +15,6 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.HashMap;
 import java.util.Map;
@@ -52,8 +51,7 @@ public class AppTest {
                 String driver = (String) options.valueOf("hive-driver");
                 Class.forName(driver);
                 String jdbcConnector = (String) options.valueOf("hive-jdbc");
-                Connection connection = DriverManager.getConnection(jdbcConnector, "", "");
-                statement = connection.createStatement();
+                connection = DriverManager.getConnection(jdbcConnector, "", "");
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

There was an issue w/ parallel execution in the REST/JSON engine since it creates one javascript engine for all queries to use at instantiation. When running in parallel, queries could redefine the js function used for result conversion resulting in a race condition where the wrong function could run on a query. e.g.

thread A -> defines function foo { implementation A }
thread B -> defines function foo { implementation B }
thread A -> calls foo on data but this is now the wrong function

The fix was to create a new javascript engine per query execution. This also removes an (unintended?) interaction where queries could define functions for re-use in the javascript engine by later queries. 

There was a similar issue w/ parallel execution in the Hive/Apiary engine since it creates one SQL Statement object for all queries to use. If a statement object is re-used, the previous ResultSet will be closed automatically. The fix was to create a Statement per query execution.

We don't have this issue with Pig since it creates a PigServer per query execution already. We also don't have this issue with the CSV engine since it only reads from files. 